### PR TITLE
Update update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,8 @@
 rm -rf source
 rm -rf source_tmp
 
-curl https://opensource.truthsocial.com/mastodon-current.zip > mastodon-current.zip
+pipx install yt-dlp[default,curl_cffi]
+yt-dlp --impersonate chrome --force-ipv4 https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip"||yt-dlp --impersonate chrome --force-ipv6 https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip"
 unzip mastodon-current.zip -d source_tmp
 
 mv source_tmp/open\ source source


### PR DESCRIPTION
As requested, here is a re-submission of #6 with only the workflow changes. Please note that I have made one change from that PR:
On line 4 I replaced `pipx install yt-dlp[curl_cffi]` with `pipx install yt-dlp[default,curl_cffi]`. Whilst installing the default dependencies takes a few seconds longer, imo it is worth it in order to future-proof the workflow

To do list (for future PRs):
1. add https://opensource.truthsocial.com/soapbox-current.zip
2. ~~add https://github.com/marketplace/actions/keepalive-workflow or something similar to prevent the workflow disabling automatically afer 60 days~~ might not be worth doing, as it's a Github TOS violation and Github disabled that specific action already