### PR TITLE
Route traffic over Tor to bypass Truth Social (captcha?)-blocking Github Actions IP addresses

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -4,7 +4,7 @@ rm -rf source_tmp
 sudo apt install torsocks
 pipx install yt-dlp[default,curl_cffi]
 # Rotate IP addresses (by restarting Tor) if we get captcha-blocked by Truth Social
-until torsocks yt-dlp --force-ipv6 --impersonate chrome https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip";do sudo service tor restart;done
+until torsocks yt-dlp --impersonate chrome https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip";do sudo service tor restart;done
 unzip mastodon-current.zip -d source_tmp
 
 mv source_tmp/open\ source source

--- a/update.sh
+++ b/update.sh
@@ -1,8 +1,10 @@
 rm -rf source
 rm -rf source_tmp
 
+sudo apt install torsocks
 pipx install yt-dlp[default,curl_cffi]
-yt-dlp --impersonate chrome --force-ipv4 https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip"||yt-dlp --impersonate chrome --force-ipv6 https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip"
+# Rotate IP addresses (by restarting Tor) if we get captcha-blocked by Truth Social
+until torsocks yt-dlp --impersonate chrome https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip";do sudo service tor restart;done
 unzip mastodon-current.zip -d source_tmp
 
 mv source_tmp/open\ source source

--- a/update.sh
+++ b/update.sh
@@ -4,7 +4,7 @@ rm -rf source_tmp
 sudo apt install torsocks
 pipx install yt-dlp[default,curl_cffi]
 # Rotate IP addresses (by restarting Tor) if we get captcha-blocked by Truth Social
-until torsocks yt-dlp --impersonate chrome https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip";do sudo service tor restart;done
+until torsocks yt-dlp --force-ipv6 --impersonate chrome https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip";do sudo service tor restart;done
 unzip mastodon-current.zip -d source_tmp
 
 mv source_tmp/open\ source source


### PR DESCRIPTION
The Github action is failing with error 403, indicating that Truth Social have likely captcha-blocked Github Actions IP addresses.
This PR bypasses the captcha-block by routing the traffic over Tor (using Torsocks). 
However, Truth Social returns error 403 to some Tor IP addresses (exit nodes). This PR bypasses that by automatically restarting Tor (and hence getting a new IP address) whenever the download fails