### PR TITLE
Replace yt-dlp with curl_cffi for Cloudflare bypass

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,8 +1,8 @@
 rm -rf source
 rm -rf source_tmp
 
-pipx install yt-dlp[default,curl_cffi]
-yt-dlp --impersonate chrome --force-ipv4 https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip"||yt-dlp --impersonate chrome --force-ipv6 https://opensource.truthsocial.com/mastodon-current.zip -o "mastodon-current.zip"
+python3 -m venv .venv && .venv/bin/pip install curl_cffi
+.venv/bin/python3 -c "from curl_cffi import requests; r = requests.get('https://opensource.truthsocial.com/mastodon-current.zip', impersonate='chrome', timeout=300); open('mastodon-current.zip','wb').write(r.content)"
 unzip mastodon-current.zip -d source_tmp
 
 mv source_tmp/open\ source source


### PR DESCRIPTION
The current `yt-dlp --impersonate` chrome approach no longer bypasses Cloudflare on https://opensource.truthsocial.com, which is likely why the hourly workflow has silently failed since May 2025.

This replaces it with [curl_cffi](https://github.com/lexiforest/curl_cffi) in a Python venv. 

I have tested the updated code in an action and it came back green: https://github.com/lnxd/truthsocial/actions/runs/23582640109